### PR TITLE
fix: v5 캘린더 디자인 마감 + 버그 4건 수정

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -138,9 +138,20 @@ body {
 
 /* ===== Header Bar — Pink Energy ===== */
 .gum-header {
-  background: var(--color-accent);
+  background: linear-gradient(180deg, var(--color-accent) 0%, color-mix(in srgb, var(--color-accent) 85%, #000) 100%);
   border-bottom: 2px solid var(--color-border-subtle);
   color: #000000;
+}
+
+.gum-header .gum-btn {
+  background: rgba(255,255,255,0.85);
+  border-color: rgba(0,0,0,0.15);
+  color: #000;
+}
+
+.gum-header .gum-btn:hover {
+  background: #FFFFFF;
+  border-color: rgba(0,0,0,0.3);
 }
 
 /* ===== Weekday Row ===== */
@@ -167,10 +178,10 @@ body {
 
 /* ===== Cell Todo Preview ===== */
 .gum-cell-preview {
-  font-size: 9px;
-  line-height: 1.2;
-  font-weight: 600;
-  color: var(--color-text-secondary);
+  font-size: 10px;
+  line-height: 1.3;
+  font-weight: 700;
+  color: var(--color-text-primary);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -180,7 +191,7 @@ body {
 
 .gum-cell-preview-done {
   text-decoration: line-through;
-  opacity: 0.4;
+  color: var(--color-text-tertiary);
 }
 
 /* ===== Stats Bar ===== */
@@ -209,10 +220,20 @@ body {
 
 /* ===== Side Panel Header ===== */
 .gum-panel-header {
-  background: var(--color-accent);
+  background: linear-gradient(180deg, var(--color-accent) 0%, color-mix(in srgb, var(--color-accent) 85%, #000) 100%);
   border-bottom: 2px solid var(--color-border-subtle);
   color: #000000;
   padding: 16px 20px;
+}
+
+.gum-panel-header .gum-btn {
+  background: rgba(255,255,255,0.85);
+  border-color: rgba(0,0,0,0.15);
+  color: #000;
+}
+
+.gum-panel-header .gum-btn:hover {
+  background: #FFFFFF;
 }
 
 /* ===== Animations ===== */

--- a/src/components/auth/LoginScreen.tsx
+++ b/src/components/auth/LoginScreen.tsx
@@ -46,8 +46,8 @@ export function LoginScreen() {
             <span className="text-lg font-black tracking-tight">Living Calendar</span>
           </div>
           <div className="flex items-center gap-3">
-            <button onClick={() => { setShowForm(true); setMode("login"); }} className="gum-btn px-5 py-2 text-sm bg-white/60 dark:bg-black/30">로그인</button>
-            <button onClick={() => { setShowForm(true); setMode("signup"); }} className="gum-btn px-5 py-2 text-sm bg-black text-white border-black dark:bg-white dark:text-black dark:border-white">시작하기</button>
+            <button onClick={() => { setShowForm(true); setMode("login"); }} className="gum-btn px-5 py-2 text-sm">로그인</button>
+            <button onClick={() => { setShowForm(true); setMode("signup"); }} className="gum-btn-pink px-5 py-2 text-sm">시작하기</button>
           </div>
         </nav>
 

--- a/src/components/calendar/CalendarGrid.tsx
+++ b/src/components/calendar/CalendarGrid.tsx
@@ -109,10 +109,10 @@ export function CalendarGrid() {
           <h1 className="text-[24px] lg:text-[28px] font-black tracking-tight">{monthLabel}</h1>
         </div>
         <div className="flex gap-2 items-center">
-          <button onClick={prevMonth} className="gum-btn w-9 h-9 text-lg bg-white/60 dark:bg-black/30">‹</button>
-          <button onClick={nextMonth} className="gum-btn w-9 h-9 text-lg bg-white/60 dark:bg-black/30">›</button>
+          <button onClick={prevMonth} className="gum-btn w-9 h-9 text-lg ">‹</button>
+          <button onClick={nextMonth} className="gum-btn w-9 h-9 text-lg ">›</button>
           <ThemeToggle />
-          <button onClick={handleLogout} className="gum-btn w-9 h-9 text-xs bg-white/60 dark:bg-black/30" aria-label="로그아웃">⏻</button>
+          <button onClick={handleLogout} className="gum-btn w-9 h-9 text-xs " aria-label="로그아웃">⏻</button>
         </div>
       </div>
 
@@ -131,25 +131,25 @@ export function CalendarGrid() {
       </div>
 
       {/* Grid — fills remaining space */}
-      <motion.div
-        ref={gridRef}
-        className="flex-1"
-        drag="x"
-        dragConstraints={{ left: 0, right: 0 }}
-        dragElastic={0.2}
-        onDragEnd={handleDragEnd}
-        animate={controls}
-        key={`${currentYear}-${currentMonth}`}
-        initial={{ x: swipeDirection * 100, opacity: 0.5 }}
-        transition={{ type: "spring", ...springs.navigate }}
-      >
-        {Array.from({ length: numWeeks }, (_, weekIdx) => {
-          const weekSegments = multiDaySegments.filter((s) => s.row === weekIdx);
-          const weekDays = cellData.slice(weekIdx * 7, weekIdx * 7 + 7);
+      <div ref={gridRef} className="flex-1 flex flex-col min-h-0 overflow-hidden">
+        <motion.div
+          className="flex-1 flex flex-col min-h-0"
+          drag="x"
+          dragConstraints={{ left: 0, right: 0 }}
+          dragElastic={0.2}
+          onDragEnd={handleDragEnd}
+          animate={controls}
+          key={`${currentYear}-${currentMonth}`}
+          initial={{ x: swipeDirection * 100, opacity: 0.5 }}
+          transition={{ type: "spring", ...springs.navigate }}
+        >
+          {Array.from({ length: numWeeks }, (_, weekIdx) => {
+            const weekSegments = multiDaySegments.filter((s) => s.row === weekIdx);
+            const weekDays = cellData.slice(weekIdx * 7, weekIdx * 7 + 7);
 
-          return (
-            <div key={weekIdx} className="relative">
-              <div className="grid grid-cols-7">
+            return (
+              <div key={weekIdx} className="relative flex-1 min-h-0 overflow-hidden">
+                <div className="grid grid-cols-7 h-full">
                 {weekDays.map((cell, colIdx) => {
                   const isCurrentMonth = cell.date.getMonth() === currentMonth;
                   const today = isToday(cell.date);
@@ -163,7 +163,7 @@ export function CalendarGrid() {
                       layoutId={`day-${cell.dateStr}`}
                       onClick={() => selectDate(cell.dateStr)}
                       className={`
-                        relative flex flex-col items-start pt-1.5 px-1 min-h-[56px] lg:min-h-0 lg:aspect-square
+                        relative flex flex-col items-start pt-1.5 px-1 min-h-[56px] lg:min-h-0 h-full
                         border-r-2 border-b-2 border-border-subtle last:border-r-0 transition-colors text-left
                         ${isCurrentMonth ? "" : "opacity-20"}
                         ${isSelected ? "bg-accent/20 ring-2 ring-inset ring-accent" : ""}
@@ -228,10 +228,11 @@ export function CalendarGrid() {
                   if (!cellDate) return null;
                   return <OverflowIndicator key={key} count={count} row={weekIdx} col={col} cellWidth={cellWidth} onTap={selectDate} date={cellDate} />;
                 })}
-            </div>
-          );
-        })}
-      </motion.div>
+              </div>
+            );
+          })}
+        </motion.div>
+      </div>
 
       {/* Monthly Stats Bar */}
       <div className="gum-stats-bar">

--- a/src/components/todo/TodoList.tsx
+++ b/src/components/todo/TodoList.tsx
@@ -58,10 +58,10 @@ export function TodoList({ desktopMode = false }: TodoListProps) {
       <div className="gum-panel-header">
         <div className="flex items-center gap-3">
           {!desktopMode && (
-            <button onClick={() => selectDate(null)} className="gum-btn w-8 h-8 text-sm font-bold bg-white/60 dark:bg-black/30">←</button>
+            <button onClick={() => selectDate(null)} className="gum-btn w-8 h-8 text-sm font-bold ">←</button>
           )}
           {desktopMode && (
-            <button onClick={() => selectDate(null)} className="gum-btn w-7 h-7 text-xs font-bold bg-white/60 dark:bg-black/30">✕</button>
+            <button onClick={() => selectDate(null)} className="gum-btn w-7 h-7 text-xs font-bold ">✕</button>
           )}
           <motion.div layoutId={desktopMode ? undefined : `day-${selectedDate}`}>
             <h1 className="text-[22px] font-black tracking-tight">


### PR DESCRIPTION
## Summary
- 핑크 헤더에 **그라데이션** + 버튼 **흰 배경/투명 보더**로 디자인 마감 개선
- 셀 투두 텍스트 **10px bold, text-primary** 색상으로 가독성 향상
- 기간 바가 캘린더 범위 벗어나는 문제 → 주 행에 **overflow-hidden** 추가
- 스와이프 월 이동 후 레이아웃 깨짐 → **gridRef 고정 컨테이너 분리 + flex-1 균등 배분**

## Test plan
- [x] `next build` 성공
- [x] vitest 43/43 통과