### PR TITLE
design: v6 Content Calendar — 전면 리디자인

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,139 +1,105 @@
-# Design System — Living Calendar (v5: Gumroad Bold + Planner)
+# Design System — Living Calendar (v6: Content Calendar)
 
 ## Product Context
 - **What this is:** 캘린더 기반 투두리스트 앱. 공간 줌 전환과 완료 효과로 차별화.
 - **Who it's for:** 매일 할 일을 관리하는 사람. 직접 사용 + 개발자 포트폴리오.
-- **Project type:** 반응형 웹앱 (모바일 우선, 데스크톱 풀스크린 캘린더)
+- **Project type:** 반응형 웹앱 (모바일 우선, 데스크톱 사이드패널)
 
 ## Aesthetic Direction
-- **Direction:** Bold Planner Kitsch — Gumroad 에너지 + 한국 월간 플래너 밀도
-- **Decoration level:** Bold — 핑크 헤더 바, 셀 안 투두 미리보기, 장식 요소, 월간 통계
-- **Mood:** 실제 플래너처럼 정보가 빽빽한 + Gumroad의 핑크 에너지. 빈 공간 최소화.
-- **Reference:** Gumroad (흑백+핑크, 볼드), 한국 월간 플래너 (셀 밀도, 요일 컬러, 메모)
+- **Direction:** Clean Minimal — Figma Content Calendar 레퍼런스 기반
+- **Decoration level:** Subtle — 장식 최소화, 정보와 여백으로 디자인
+- **Mood:** 깔끔하고 프로페셔널. 노이즈 없이 기능에 집중.
+- **Reference:** Figma Content Calendar with Auto Layout 2025
 
 ## Typography
-- **Display/Hero:** Pretendard Variable 800 / 48px — 랜딩 페이지 헤드라인
-- **Title:** Pretendard Variable 700 / 24px — 월 헤더
-- **Subtitle:** Pretendard Variable 600 / 18px — 투두 화면 날짜
-- **Body:** Pretendard Variable 400 / 15px — line-height 1.5
-- **UI/Labels:** Pretendard Variable 600 / 12px — letter-spacing 0.02em
-- **Code:** Geist Mono
+- **Title:** Pretendard Variable 600 / 19px — 월 헤더
+- **Subtitle:** Pretendard Variable 600 / 17px — 날짜 헤더
+- **Body:** Pretendard Variable 400 / 14px — 투두 텍스트
+- **Small:** Pretendard Variable 500 / 12px — 레이블, 카테고리
+- **Micro:** Pretendard Variable 500 / 10-11px — 셀 내 미리보기, 뱃지
 
 ## Color
-- **Approach:** 흑백 고대비 + #FF90E8 핑크 포인트 (Gumroad signature)
 
-### Light Mode (기본)
-
-#### Surfaces
+### Light Mode
 | Token | Value | Usage |
 |-------|-------|-------|
-| --bg-primary | #FFFFFF | 앱 배경 (순백) |
-| --bg-secondary | #F4F4F0 | 카드, 캘린더 셀 (따뜻한 오프화이트) |
-| --bg-elevated | #E8E8E4 | hover, 선택된 셀 |
-| --border-subtle | #E0E0DC | 구분선, 그리드 |
-
-#### Text
-| Token | Value | Usage |
-|-------|-------|-------|
-| --text-primary | #000000 | 주요 텍스트 (순흑) |
-| --text-secondary | #666666 | 부가 정보 |
-| --text-tertiary | #999999 | placeholder, 완료 항목 |
-
-#### Accent & Semantic
-| Token | Value | Usage |
-|-------|-------|-------|
-| --accent | #FF90E8 | CTA 버튼, 오늘 표시, 포인트 (Gumroad Pink) |
-| --accent-hover | #FF6AD5 | 버튼 hover |
-| --success | #23C45E | 완료 체크 |
-| --warning | #FFB800 | 경고 |
-| --error | #FF4444 | 오류, 삭제 |
-
-#### Categories (키치한 컬러셋)
-| Token | Value | Name |
-|-------|-------|------|
-| --cat-pink | #FF90E8 | Pink |
-| --cat-yellow | #FFE14D | Yellow |
-| --cat-green | #23C45E | Green |
-| --cat-blue | #4DA6FF | Blue |
-| --cat-purple | #B266FF | Purple |
-| --cat-orange | #FF8A4D | Orange |
-| --cat-red | #FF4D6A | Red |
+| --bg-primary | #FFFFFF | 카드, 캘린더 배경 |
+| --bg-secondary | #F8F9FA | 앱 배경, 입력 필드 |
+| --bg-elevated | #FFFFFF | 패널, 모달 |
+| --border | #E5E7EB | 주요 보더 |
+| --border-light | #F0F1F3 | 셀 구분선 |
+| --text-primary | #111827 | 본문 |
+| --text-secondary | #6B7280 | 보조 |
+| --text-tertiary | #9CA3AF | placeholder |
+| --accent | #6366F1 | CTA, 선택 상태 (Indigo) |
+| --accent-light | #EEF2FF | 선택된 셀, hover |
+| --success | #10B981 | 완료 |
+| --error | #EF4444 | 에러 |
+| --sun | #EF4444 | 일요일 |
+| --sat | #3B82F6 | 토요일 |
 
 ### Dark Mode
-| Token | Light | Dark |
-|-------|-------|------|
-| --bg-primary | #FFFFFF | #000000 |
-| --bg-secondary | #F4F4F0 | #1A1A1A |
-| --bg-elevated | #E8E8E4 | #2A2A2A |
-| --border-subtle | #E0E0DC | #333333 |
-| --text-primary | #000000 | #FFFFFF |
-| --text-secondary | #666666 | #999999 |
-| --text-tertiary | #999999 | #666666 |
-| --accent | #FF90E8 | #FF90E8 (동일) |
+| Token | Value |
+|-------|-------|
+| --bg-primary | #111111 |
+| --bg-secondary | #1A1A1A |
+| --bg-elevated | #1F1F1F |
+| --border | #2E2E2E |
+| --border-light | #252525 |
+| --text-primary | #F3F4F6 |
+| --accent | #818CF8 |
 
 ## Layout
 
 ### Breakpoints
 | Breakpoint | Width | Layout |
 |-----------|-------|--------|
-| Mobile | < 768px | 전체 너비, 캘린더/투두 전환 |
-| Tablet | 768px+ | 중앙 정렬, 캘린더/투두 전환 |
-| Desktop | 1024px+ | 풀스크린 캘린더(좌 flex-1) + 투두 사이드패널(400px) |
+| Mobile | < 768px | 전체 너비, 패딩 12px, 캘린더/투두 전환 |
+| Desktop | 1024px+ | 캘린더(flex-1) + 투두 사이드패널(380px), 패딩 12px |
+
+### Spacing
+- 앱 배경에 패딩 → 카드가 떠 있는 느낌
+- 카드 내부 패딩: 16-20px
+- 요소 간 gap: 12px
 
 ### Border Radius
 | Token | Value | Usage |
 |-------|-------|-------|
-| --radius-sm | 4px | 체크박스 |
-| --radius-md | 8px | 입력 필드, 카드 |
-| --radius-lg | 12px | 모달, 큰 카드 |
-| --radius-full | 9999px | 버튼, 뱃지, 오늘 표시 |
+| --radius-sm | 6px | 체크박스, 인풋 |
+| --radius-md | 10px | 카드, 버튼 |
+| --radius-lg | 14px | 패널, 모달 |
+| --radius-full | 9999px | 뱃지, 태그 |
 
 ### Card Style
-- Background: var(--bg-secondary)
-- Border: 2px solid var(--border-subtle)
-- Shadow: none (flat design)
-- Border-radius: var(--radius-md)
+- Background: var(--bg-elevated)
+- Border: 1px solid var(--border)
+- Border-radius: var(--radius-lg) (desktop), var(--radius-md) (mobile)
+- Shadow: none
 
-## Character — Doto (도토)
-- 연필 모양 캐릭터, 체크마크 머리
-- SVG로 구현, 다양한 표정/포즈
-- 랜딩: 큰 사이즈, 인사 포즈
-- 빈 상태: 작은 사이즈, 졸고 있는 포즈
-- 완료 시: 축하 포즈
+## Calendar Grid
+- **Header:** 좌우 화살표 (SVG) + 월 타이틀 + 테마토글 + 로그아웃
+- **Weekday Row:** 일=빨강, 토=파랑, 나머지=tertiary
+- **Cell:** 날짜 + 카테고리 dot (모바일) / 투두 미리보기 2줄 (데스크톱)
+- **Today:** accent 원 배경 + 흰 텍스트
+- **Selected:** accent-light 배경
+- **MultiDay Bar:** 카테고리 컬러 왼쪽 보더 + 투명 배경
 
-## Calendar Grid (v5 추가)
-- **Header:** 핑크(accent) 배경 바. Doto 캐릭터 + 월 타이틀
-- **Weekday Row:** bg-secondary 배경. 일요일 빨강, 토요일 파랑
-- **Cell 미리보기:** 데스크톱에서 셀 안에 투두 타이틀 최대 3개 표시 (9px)
-- **Cell 배경:** 투두 있으면 accent/6% 틴트, 모두 완료 시 success/8% 틴트
-- **Selected Cell:** accent/20% 배경 + accent ring
-- **Stats Bar:** 하단에 월간 통계 (할 일 수, 완료 수, 달성률, Doto 무드)
-
-## Side Panel (v5 추가)
-- **Header:** 핑크 배경 + 날짜/요일 + 미니 프로그레스 바
-- **Close button:** 헤더 안에 통합
-
-## Landing Page
-- **Nav:** 핑크 배경 헤더 바 (앱과 동일한 무드)
-- 대형 타이포: "할 일을 끝내는\n가장 쉬운 방법" (48px, bold)
-- **장식 요소:** 플로팅 원/사각형 (accent, yellow, green, blue, purple)
-- Doto 캐릭터 배치
-- CTA 버튼: #FF90E8 핑크, 큰 사이즈, rounded-full
+## Side Panel
+- **Header:** 날짜 + 요일 + 진행률 (프로그레스 바)
+- **Empty state:** + 아이콘 + 안내 문구
+- **Todo item:** 체크박스(둥근 사각형) + 텍스트 + 카테고리 뱃지
 
 ## Motion
 - **Library:** Framer Motion
-- 체크박스 완료: 바운스 + 핑크 파티클
-- 월 전환: 좌우 슬라이드
+- 체크 완료: 바운스 + 파티클
+- 월 전환: 좌우 슬라이드 (스와이프)
 - 투두 리스트: stagger fade-in
 
 ## Decisions Log
 | Date | Decision | Rationale |
 |------|----------|-----------|
-| 2026-04-08 | v4: Gumroad 스타일 전면 리디자인 | 사용자 피드백: 가시성 부족, 눈 피로. Gumroad의 심플+키치+고대비 스타일 채택 |
-| 2026-04-08 | 흑백+핑크 컬러 시스템 | 높은 가시성 + 개성. #FF90E8 Gumroad signature pink |
-| 2026-04-08 | Doto 캐릭터 추가 | 키치한 개성, 빈 상태/랜딩 활용 |
-| 2026-04-08 | 데스크톱 풀스크린 캘린더 | 캘린더가 주인공. 데스크톱에서 화면 가득 차도록 |
-| 2026-04-08 | v5: 핑크 헤더 바 + 셀 투두 미리보기 | 피드백: 보더만으로는 무드 안 나옴. 플래너 레퍼런스 참고하여 정보 밀도 + 핑크 에너지 강화 |
-| 2026-04-08 | 월간 통계 바 | 하단 통계로 빈 공간 활용 + 달성감 제공 |
-| 2026-04-08 | 요일별 컬러 (일=빨강, 토=파랑) | 한국 플래너 관례. 가독성 향상 |
-| 2026-04-08 | 사이드패널 핑크 헤더 + 프로그레스 바 | 사이드패널도 핑크 에너지. 진행률 시각화 |
+| 2026-04-08 | v6: Content Calendar 스타일 전면 리디자인 | 기존 Gumroad 스타일이 조잡함. Figma Content Calendar 기반 클린 미니멀로 전환 |
+| 2026-04-08 | Indigo accent (#6366F1) | 핑크에서 인디고로. 프로페셔널하면서 차분한 톤 |
+| 2026-04-08 | 가벼운 보더 (1px, #E5E7EB) | 검정 2px 보더 제거. 미세한 그레이 보더로 구분 |
+| 2026-04-08 | 배경에 패딩 + 카드 분리 | 앱 배경(secondary) 위에 카드(elevated)가 떠 있는 레이아웃 |
+| 2026-04-08 | Doto 캐릭터 제거 | 클린 미니멀에 캐릭터가 안 어울림. SVG 아이콘으로 대체 |

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,68 +1,77 @@
 @import "tailwindcss";
 
-/* ===== v5: Gumroad Bold — Thick Borders + Pink Energy ===== */
+/* ===== v6: Content Calendar — Clean Minimal ===== */
 
 :root {
   --color-bg-primary: #FFFFFF;
-  --color-bg-secondary: #F4F4F0;
-  --color-bg-elevated: #E8E8E4;
-  --color-border-subtle: #000000;
+  --color-bg-secondary: #F8F9FA;
+  --color-bg-elevated: #FFFFFF;
+  --color-border: #E5E7EB;
+  --color-border-light: #F0F1F3;
 
-  --color-text-primary: #000000;
-  --color-text-secondary: #555555;
-  --color-text-tertiary: #999999;
+  --color-text-primary: #111827;
+  --color-text-secondary: #6B7280;
+  --color-text-tertiary: #9CA3AF;
 
-  --color-accent: #FF90E8;
-  --color-accent-hover: #FF6AD5;
-  --color-success: #23C45E;
-  --color-warning: #FFB800;
-  --color-error: #FF4444;
+  --color-accent: #6366F1;
+  --color-accent-light: #EEF2FF;
+  --color-accent-hover: #4F46E5;
+  --color-success: #10B981;
+  --color-success-light: #ECFDF5;
+  --color-warning: #F59E0B;
+  --color-error: #EF4444;
+  --color-error-light: #FEF2F2;
+
+  --color-sun: #EF4444;
+  --color-sat: #3B82F6;
 }
 
 .dark {
-  --color-bg-primary: #000000;
-  --color-bg-secondary: #141414;
-  --color-bg-elevated: #222222;
-  --color-border-subtle: #FFFFFF;
+  --color-bg-primary: #111111;
+  --color-bg-secondary: #1A1A1A;
+  --color-bg-elevated: #1F1F1F;
+  --color-border: #2E2E2E;
+  --color-border-light: #252525;
 
-  --color-text-primary: #FFFFFF;
-  --color-text-secondary: #AAAAAA;
-  --color-text-tertiary: #666666;
+  --color-text-primary: #F3F4F6;
+  --color-text-secondary: #9CA3AF;
+  --color-text-tertiary: #6B7280;
 
-  --color-accent: #FF90E8;
-  --color-accent-hover: #FF6AD5;
-  --color-success: #34D96B;
-  --color-warning: #FFD54F;
-  --color-error: #FF6B6B;
+  --color-accent: #818CF8;
+  --color-accent-light: rgba(99,102,241,0.1);
+  --color-accent-hover: #6366F1;
+  --color-success: #34D399;
+  --color-success-light: rgba(16,185,129,0.1);
+  --color-warning: #FBBF24;
+  --color-error: #F87171;
+  --color-error-light: rgba(239,68,68,0.1);
 }
 
 @theme {
   --color-bg-primary: var(--color-bg-primary);
   --color-bg-secondary: var(--color-bg-secondary);
   --color-bg-elevated: var(--color-bg-elevated);
-  --color-border-subtle: var(--color-border-subtle);
+  --color-border: var(--color-border);
+  --color-border-light: var(--color-border-light);
   --color-text-primary: var(--color-text-primary);
   --color-text-secondary: var(--color-text-secondary);
   --color-text-tertiary: var(--color-text-tertiary);
   --color-accent: var(--color-accent);
+  --color-accent-light: var(--color-accent-light);
   --color-accent-hover: var(--color-accent-hover);
   --color-success: var(--color-success);
+  --color-success-light: var(--color-success-light);
   --color-warning: var(--color-warning);
   --color-error: var(--color-error);
+  --color-error-light: var(--color-error-light);
+  --color-sun: var(--color-sun);
+  --color-sat: var(--color-sat);
 }
 
 @theme inline {
-  --color-cat-pink: #FF90E8;
-  --color-cat-yellow: #FFE14D;
-  --color-cat-green: #23C45E;
-  --color-cat-blue: #4DA6FF;
-  --color-cat-purple: #B266FF;
-  --color-cat-orange: #FF8A4D;
-  --color-cat-red: #FF4D6A;
-
-  --radius-sm: 4px;
-  --radius-md: 8px;
-  --radius-lg: 12px;
+  --radius-sm: 6px;
+  --radius-md: 10px;
+  --radius-lg: 14px;
   --radius-full: 9999px;
 
   --font-sans: "Pretendard Variable", -apple-system, BlinkMacSystemFont, system-ui, sans-serif;
@@ -70,199 +79,27 @@
 }
 
 body {
-  background: var(--color-bg-primary);
+  background: var(--color-bg-secondary);
   color: var(--color-text-primary);
   font-family: var(--font-sans);
 }
 
-/* ===== Gumroad-style Card ===== */
-.gum-card {
-  background: var(--color-bg-primary);
-  border: 2px solid var(--color-border-subtle);
-  border-radius: var(--radius-md);
-}
-
-.gum-card-pink {
-  background: var(--color-accent);
-  border: 2px solid var(--color-border-subtle);
-  border-radius: var(--radius-md);
-  color: #000000;
-}
-
-.gum-btn {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  font-weight: 700;
-  border: 2px solid var(--color-border-subtle);
-  border-radius: var(--radius-full);
-  transition: all 0.15s ease;
-}
-
-.gum-btn:hover {
-  background: var(--color-accent);
-  color: #000000;
-}
-
-.gum-btn-pink {
-  background: var(--color-accent);
-  color: #000000;
-  font-weight: 700;
-  border: 2px solid var(--color-border-subtle);
-  border-radius: var(--radius-full);
-  transition: all 0.15s ease;
-}
-
-.gum-btn-pink:hover {
-  background: var(--color-accent-hover);
-}
-
-.gum-input {
-  width: 100%;
-  background: var(--color-bg-primary);
-  border: 2px solid var(--color-border-subtle);
-  border-radius: var(--radius-md);
-  padding: 12px 16px;
-  font-size: 15px;
-  outline: none;
-  transition: border-color 0.15s ease;
-}
-
-.gum-input:focus {
-  border-color: var(--color-accent);
-}
-
-.gum-input::placeholder {
-  color: var(--color-text-tertiary);
-}
-
-/* ===== Header Bar — Pink Energy ===== */
-.gum-header {
-  background: linear-gradient(180deg, var(--color-accent) 0%, color-mix(in srgb, var(--color-accent) 85%, #000) 100%);
-  border-bottom: 2px solid var(--color-border-subtle);
-  color: #000000;
-}
-
-.gum-header .gum-btn {
-  background: rgba(255,255,255,0.85);
-  border-color: rgba(0,0,0,0.15);
-  color: #000;
-}
-
-.gum-header .gum-btn:hover {
-  background: #FFFFFF;
-  border-color: rgba(0,0,0,0.3);
-}
-
-/* ===== Weekday Row ===== */
-.gum-weekday-row {
-  background: var(--color-bg-secondary);
-}
-
-.gum-weekday-sun {
-  color: #FF4D6A;
-}
-
-.gum-weekday-sat {
-  color: #4DA6FF;
-}
-
-/* ===== Cell with content — subtle fill ===== */
-.gum-cell-has-todos {
-  background: color-mix(in srgb, var(--color-accent) 6%, transparent);
-}
-
-.gum-cell-all-done {
-  background: color-mix(in srgb, var(--color-success) 8%, transparent);
-}
-
-/* ===== Cell Todo Preview ===== */
-.gum-cell-preview {
-  font-size: 10px;
-  line-height: 1.3;
-  font-weight: 700;
-  color: var(--color-text-primary);
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  max-width: 100%;
-  padding: 0 2px;
-}
-
-.gum-cell-preview-done {
-  text-decoration: line-through;
-  color: var(--color-text-tertiary);
-}
-
-/* ===== Stats Bar ===== */
-.gum-stats-bar {
-  background: var(--color-bg-secondary);
-  border-top: 2px solid var(--color-border-subtle);
-  padding: 8px 16px;
-  display: flex;
-  align-items: center;
-  gap: 16px;
-  font-size: 12px;
-  font-weight: 700;
-}
-
-.gum-stat-pill {
-  display: inline-flex;
-  align-items: center;
-  gap: 4px;
-  padding: 2px 10px;
-  border-radius: var(--radius-full);
-  border: 2px solid var(--color-border-subtle);
-  background: var(--color-bg-primary);
-  font-size: 11px;
-  font-weight: 800;
-}
-
-/* ===== Side Panel Header ===== */
-.gum-panel-header {
-  background: linear-gradient(180deg, var(--color-accent) 0%, color-mix(in srgb, var(--color-accent) 85%, #000) 100%);
-  border-bottom: 2px solid var(--color-border-subtle);
-  color: #000000;
-  padding: 16px 20px;
-}
-
-.gum-panel-header .gum-btn {
-  background: rgba(255,255,255,0.85);
-  border-color: rgba(0,0,0,0.15);
-  color: #000;
-}
-
-.gum-panel-header .gum-btn:hover {
-  background: #FFFFFF;
-}
-
 /* ===== Animations ===== */
-@keyframes breathe {
-  0%, 100% { opacity: 0.4; }
-  50% { opacity: 0.7; }
-}
-
 @keyframes spin {
   to { transform: rotate(360deg); }
 }
 
 @keyframes today-pulse {
-  0%, 100% { box-shadow: 0 0 0 0 rgba(255, 144, 232, 0.5); }
-  50% { box-shadow: 0 0 0 6px rgba(255, 144, 232, 0); }
+  0%, 100% { box-shadow: 0 0 0 0 rgba(99, 102, 241, 0.3); }
+  50% { box-shadow: 0 0 0 4px rgba(99, 102, 241, 0); }
 }
 
 @keyframes float {
   0%, 100% { transform: translateY(0); }
-  50% { transform: translateY(-10px); }
+  50% { transform: translateY(-8px); }
 }
 
-@keyframes wave {
-  0%, 100% { transform: rotate(0deg); }
-  25% { transform: rotate(14deg); }
-  75% { transform: rotate(-14deg); }
-}
-
-@keyframes slideUp {
-  from { opacity: 0; transform: translateY(20px); }
+@keyframes fadeIn {
+  from { opacity: 0; transform: translateY(8px); }
   to { opacity: 1; transform: translateY(0); }
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { AnimatePresence, LayoutGroup, motion } from "framer-motion";
+import { AnimatePresence, motion } from "framer-motion";
 import { useCalendarStore } from "@/stores/calendarStore";
 import { CalendarGrid } from "@/components/calendar/CalendarGrid";
 import { TodoList } from "@/components/todo/TodoList";
@@ -34,7 +34,6 @@ export default function Home() {
 
 function AppContent() {
   const selectedDate = useCalendarStore((s) => s.selectedDate);
-  const selectDate = useCalendarStore((s) => s.selectDate);
   const [initialized, setInitialized] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -57,10 +56,10 @@ function AppContent() {
 
   if (error) {
     return (
-      <main className="min-h-screen flex items-center justify-center px-6">
-        <div className="gum-card p-8 text-center max-w-sm">
-          <p className="text-error text-sm font-bold mb-4">{error}</p>
-          <button onClick={() => { setError(null); setInitialized(false); }} className="gum-btn-pink px-6 py-2 text-sm">다시 시도</button>
+      <main className="min-h-screen flex items-center justify-center px-6 bg-bg-secondary">
+        <div className="bg-bg-elevated border border-border rounded-xl p-8 text-center max-w-sm">
+          <p className="text-error text-[14px] mb-4">{error}</p>
+          <button onClick={() => { setError(null); setInitialized(false); }} className="px-6 py-2 bg-accent text-white text-[13px] font-medium rounded-lg hover:bg-accent-hover transition-colors">다시 시도</button>
         </div>
       </main>
     );
@@ -68,42 +67,46 @@ function AppContent() {
 
   if (!initialized) {
     return (
-      <main className="min-h-screen flex items-center justify-center">
-        <div className="w-6 h-6 border-[3px] border-accent border-t-transparent rounded-full" style={{ animation: "spin 0.8s linear infinite" }} />
+      <main className="min-h-screen flex items-center justify-center bg-bg-secondary">
+        <div className="w-5 h-5 border-2 border-accent border-t-transparent rounded-full" style={{ animation: "spin 0.8s linear infinite" }} />
       </main>
     );
   }
 
   return (
-    <main className="min-h-screen">
-      <LayoutGroup>
-        {/* Desktop: fullscreen calendar + closable side panel */}
-        <div className="hidden lg:flex min-h-screen">
-          <div className="flex-1 min-w-0">
-            <CalendarGrid />
-          </div>
-          <AnimatePresence>
-            {selectedDate && (
-              <motion.div
-                className="w-[420px] flex-shrink-0 border-l-2 border-border-subtle overflow-hidden"
-                initial={{ width: 0, opacity: 0 }}
-                animate={{ width: 420, opacity: 1 }}
-                exit={{ width: 0, opacity: 0 }}
-                transition={{ type: "spring", stiffness: 300, damping: 30 }}
-              >
-                <TodoList desktopMode />
-              </motion.div>
-            )}
-          </AnimatePresence>
+    <main className="min-h-screen bg-bg-secondary">
+      {/* Desktop */}
+      <div className="hidden lg:flex min-h-screen p-3 gap-3">
+        <div className="flex-1 min-w-0">
+          <CalendarGrid />
         </div>
+        <AnimatePresence>
+          {selectedDate && (
+            <motion.div
+              className="w-[380px] flex-shrink-0 bg-bg-elevated border border-border rounded-xl overflow-hidden"
+              initial={{ width: 0, opacity: 0 }}
+              animate={{ width: 380, opacity: 1 }}
+              exit={{ width: 0, opacity: 0 }}
+              transition={{ type: "spring", stiffness: 300, damping: 30 }}
+            >
+              <TodoList desktopMode />
+            </motion.div>
+          )}
+        </AnimatePresence>
+      </div>
 
-        {/* Mobile/Tablet */}
-        <div className="lg:hidden">
-          <AnimatePresence mode="wait">
-            {selectedDate ? <TodoList key="todo" /> : <CalendarGrid key="calendar" />}
-          </AnimatePresence>
-        </div>
-      </LayoutGroup>
+      {/* Mobile/Tablet */}
+      <div className="lg:hidden">
+        <AnimatePresence mode="wait">
+          {selectedDate ? (
+            <TodoList key="todo" />
+          ) : (
+            <div key="calendar" className="p-3 min-h-screen">
+              <CalendarGrid />
+            </div>
+          )}
+        </AnimatePresence>
+      </div>
     </main>
   );
 }

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -23,10 +23,14 @@ export function ThemeToggle() {
   return (
     <button
       onClick={toggle}
-      className="gum-btn w-9 h-9 text-sm"
+      className="w-8 h-8 flex items-center justify-center rounded-lg text-text-secondary hover:bg-bg-secondary transition-colors"
       aria-label={dark ? "라이트 모드로 전환" : "다크 모드로 전환"}
     >
-      {dark ? "☀️" : "🌙"}
+      {dark ? (
+        <svg width="16" height="16" viewBox="0 0 16 16" fill="none"><circle cx="8" cy="8" r="3" stroke="currentColor" strokeWidth="1.5"/><path d="M8 1v2M8 13v2M1 8h2M13 8h2M3.05 3.05l1.414 1.414M11.536 11.536l1.414 1.414M3.05 12.95l1.414-1.414M11.536 4.464l1.414-1.414" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round"/></svg>
+      ) : (
+        <svg width="16" height="16" viewBox="0 0 16 16" fill="none"><path d="M14 10.167A6 6 0 015.833 2 6.002 6.002 0 008 14a6.002 6.002 0 006-3.833z" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/></svg>
+      )}
     </button>
   );
 }

--- a/src/components/auth/LoginScreen.tsx
+++ b/src/components/auth/LoginScreen.tsx
@@ -4,7 +4,6 @@ import { useState } from "react";
 import { motion } from "framer-motion";
 import { createClient } from "@/lib/supabase";
 import { springs } from "@/lib/springs";
-import { Doto } from "@/components/Doto";
 
 type Mode = "login" | "signup";
 
@@ -38,77 +37,62 @@ export function LoginScreen() {
 
   if (!showForm) {
     return (
-      <div className="min-h-screen flex flex-col">
-        {/* Nav — pink */}
-        <nav className="gum-header flex items-center justify-between px-6 py-3">
+      <div className="min-h-screen flex flex-col bg-bg-secondary">
+        {/* Nav */}
+        <nav className="flex items-center justify-between px-6 py-4">
+          <span className="text-[17px] font-semibold tracking-tight">Living Calendar</span>
           <div className="flex items-center gap-2">
-            <Doto mood="wave" size={28} />
-            <span className="text-lg font-black tracking-tight">Living Calendar</span>
-          </div>
-          <div className="flex items-center gap-3">
-            <button onClick={() => { setShowForm(true); setMode("login"); }} className="gum-btn px-5 py-2 text-sm">로그인</button>
-            <button onClick={() => { setShowForm(true); setMode("signup"); }} className="gum-btn-pink px-5 py-2 text-sm">시작하기</button>
+            <button onClick={() => { setShowForm(true); setMode("login"); }} className="px-4 py-2 text-[13px] font-medium text-text-secondary hover:text-text-primary transition-colors">로그인</button>
+            <button onClick={() => { setShowForm(true); setMode("signup"); }} className="px-4 py-2 text-[13px] font-medium bg-accent text-white rounded-lg hover:bg-accent-hover transition-colors">시작하기</button>
           </div>
         </nav>
 
-        <div className="flex-1 flex flex-col items-center justify-center px-6 py-12 relative overflow-hidden">
-          {/* Decorative floating shapes */}
-          <motion.div className="absolute top-16 left-[10%] w-12 h-12 rounded-full bg-accent/20 border-2 border-accent/30" style={{ animation: "float 4s ease-in-out infinite" }} />
-          <motion.div className="absolute top-32 right-[12%] w-8 h-8 rounded-sm bg-cat-yellow/30 border-2 border-cat-yellow/40 rotate-12" style={{ animation: "float 5s ease-in-out infinite 0.5s" }} />
-          <motion.div className="absolute bottom-32 left-[15%] w-6 h-6 rounded-full bg-cat-green/25 border-2 border-cat-green/35" style={{ animation: "float 3.5s ease-in-out infinite 1s" }} />
-          <motion.div className="absolute bottom-24 right-[18%] w-10 h-10 rounded-full bg-cat-blue/20 border-2 border-cat-blue/30" style={{ animation: "float 4.5s ease-in-out infinite 0.3s" }} />
-          <motion.div className="absolute top-48 left-[5%] w-4 h-4 rounded-full bg-cat-purple/30" style={{ animation: "float 3s ease-in-out infinite 0.7s" }} />
-
-          <motion.div initial={{ y: 30, opacity: 0 }} animate={{ y: 0, opacity: 1 }} transition={{ type: "spring", ...springs.navigate }} className="flex flex-col items-center relative z-10">
-            <motion.div className="gum-card-pink px-6 py-2 mb-6 text-sm font-black" initial={{ scale: 0.8, opacity: 0 }} animate={{ scale: 1, opacity: 1 }} transition={{ delay: 0.1 }}>
-              무료로 시작하세요 ✨
+        <div className="flex-1 flex flex-col items-center justify-center px-6 pb-20">
+          <motion.div initial={{ y: 20, opacity: 0 }} animate={{ y: 0, opacity: 1 }} transition={{ type: "spring", ...springs.navigate }} className="flex flex-col items-center max-w-lg">
+            {/* Icon */}
+            <motion.div
+              className="w-16 h-16 rounded-2xl bg-accent/10 flex items-center justify-center mb-6"
+              initial={{ scale: 0.8 }} animate={{ scale: 1 }} transition={{ delay: 0.1, type: "spring", stiffness: 300 }}
+            >
+              <svg width="32" height="32" viewBox="0 0 32 32" fill="none">
+                <rect x="4" y="6" width="24" height="22" rx="3" stroke="var(--color-accent)" strokeWidth="2"/>
+                <path d="M4 12h24" stroke="var(--color-accent)" strokeWidth="2"/>
+                <path d="M10 4v4M22 4v4" stroke="var(--color-accent)" strokeWidth="2" strokeLinecap="round"/>
+                <circle cx="12" cy="20" r="2" fill="var(--color-accent)"/>
+                <circle cx="20" cy="20" r="2" fill="var(--color-accent)" opacity="0.4"/>
+              </svg>
             </motion.div>
 
-            <h1 className="text-[48px] md:text-[72px] font-black leading-[1.05] tracking-tight text-center max-w-3xl">
+            <h1 className="text-[36px] md:text-[48px] font-semibold leading-[1.1] tracking-tight text-center">
               할 일을 끝내는
               <br />
-              <span className="relative inline-block">
-                가장 쉬운 방법
-                <svg className="absolute -bottom-2 left-0 w-full h-4" viewBox="0 0 300 12" preserveAspectRatio="none">
-                  <path d="M0 8 Q75 0 150 8 Q225 16 300 8" stroke="#FF90E8" strokeWidth="4" fill="none" />
-                </svg>
-              </span>
+              가장 쉬운 방법
             </h1>
 
-            <p className="text-text-secondary text-lg md:text-xl mt-6 text-center max-w-md leading-relaxed">
+            <p className="text-text-secondary text-[16px] md:text-[18px] mt-4 text-center leading-relaxed">
               캘린더에서 날짜를 누르고, 할 일을 적고, 끝내세요.
             </p>
 
-            <motion.div className="flex gap-3 mt-8" initial={{ y: 20, opacity: 0 }} animate={{ y: 0, opacity: 1 }} transition={{ delay: 0.3 }}>
-              <button onClick={() => { setShowForm(true); setMode("signup"); }} className="gum-btn-pink px-10 py-4 text-lg">시작하기 →</button>
+            <motion.div className="flex gap-3 mt-8" initial={{ y: 10, opacity: 0 }} animate={{ y: 0, opacity: 1 }} transition={{ delay: 0.2 }}>
+              <button onClick={() => { setShowForm(true); setMode("signup"); }} className="px-8 py-3 bg-accent text-white text-[15px] font-medium rounded-xl hover:bg-accent-hover transition-colors">
+                무료로 시작하기
+              </button>
             </motion.div>
           </motion.div>
 
-          {/* Feature cards — compact grid */}
-          <motion.div className="grid grid-cols-1 md:grid-cols-3 gap-3 mt-14 max-w-2xl w-full relative z-10" initial={{ y: 40, opacity: 0 }} animate={{ y: 0, opacity: 1 }} transition={{ delay: 0.5 }}>
+          {/* Feature cards */}
+          <motion.div className="grid grid-cols-1 md:grid-cols-3 gap-3 mt-16 max-w-xl w-full" initial={{ y: 30, opacity: 0 }} animate={{ y: 0, opacity: 1 }} transition={{ delay: 0.4 }}>
             {[
-              { emoji: "📅", title: "캘린더 뷰", desc: "한 눈에 보는 할 일", accent: "#FF90E8" },
-              { emoji: "✅", title: "완료 효과", desc: "끝내면 파티클이 터짐", accent: "#23C45E" },
-              { emoji: "🔄", title: "루틴 관리", desc: "반복 할 일 자동 생성", accent: "#4DA6FF" },
-            ].map((f, i) => (
-              <motion.div
-                key={f.title}
-                className="gum-card p-4 text-center"
-                initial={{ y: 20, opacity: 0 }}
-                animate={{ y: 0, opacity: 1 }}
-                transition={{ delay: 0.6 + i * 0.1 }}
-                whileHover={{ y: -4, borderColor: f.accent }}
-              >
-                <div className="text-2xl mb-1.5">{f.emoji}</div>
-                <div className="font-black text-sm">{f.title}</div>
-                <div className="text-text-secondary text-xs mt-0.5">{f.desc}</div>
-              </motion.div>
+              { icon: "📅", title: "캘린더 뷰", desc: "한 눈에 보는 할 일" },
+              { icon: "✓", title: "완료 효과", desc: "끝내면 파티클이 터짐" },
+              { icon: "↻", title: "루틴 관리", desc: "반복 할 일 자동 생성" },
+            ].map((f) => (
+              <div key={f.title} className="bg-bg-elevated border border-border rounded-xl p-4 text-center">
+                <div className="text-[20px] mb-1.5">{f.icon}</div>
+                <div className="text-[13px] font-medium">{f.title}</div>
+                <div className="text-text-tertiary text-[12px] mt-0.5">{f.desc}</div>
+              </div>
             ))}
-          </motion.div>
-
-          {/* Doto character */}
-          <motion.div className="mt-10" style={{ animation: "float 3s ease-in-out infinite" }} initial={{ opacity: 0 }} animate={{ opacity: 1 }} transition={{ delay: 0.8 }}>
-            <Doto mood="wave" size={80} />
           </motion.div>
         </div>
       </div>
@@ -116,45 +100,39 @@ export function LoginScreen() {
   }
 
   return (
-    <div className="min-h-screen flex flex-col">
-      <nav className="gum-header flex items-center justify-between px-6 py-3">
-        <button onClick={() => setShowForm(false)} className="flex items-center gap-2 hover:opacity-70 transition-opacity">
-          <Doto mood="wave" size={28} />
-          <span className="text-lg font-black tracking-tight">Living Calendar</span>
-        </button>
+    <div className="min-h-screen flex flex-col bg-bg-secondary">
+      <nav className="flex items-center px-6 py-4">
+        <button onClick={() => setShowForm(false)} className="text-[17px] font-semibold tracking-tight hover:text-accent transition-colors">Living Calendar</button>
       </nav>
 
       <div className="flex-1 flex items-center justify-center px-6">
-        <motion.div className="w-full max-w-[400px]" initial={{ y: 20, opacity: 0 }} animate={{ y: 0, opacity: 1 }} transition={{ type: "spring", ...springs.navigate }}>
-          <div className="flex items-center gap-3 mb-6">
-            <Doto mood="think" size={48} />
-            <div>
-              <h2 className="text-2xl font-black">{mode === "login" ? "다시 오셨군요!" : "반가워요!"}</h2>
-              <p className="text-text-secondary text-sm">{mode === "login" ? "로그인하고 이어서 해요" : "10초면 끝나요"}</p>
-            </div>
+        <motion.div className="w-full max-w-[380px]" initial={{ y: 16, opacity: 0 }} animate={{ y: 0, opacity: 1 }} transition={{ type: "spring", ...springs.navigate }}>
+          <div className="mb-6">
+            <h2 className="text-[24px] font-semibold">{mode === "login" ? "다시 오셨군요" : "반가워요"}</h2>
+            <p className="text-text-secondary text-[14px] mt-1">{mode === "login" ? "로그인하고 이어서 해요" : "10초면 시작할 수 있어요"}</p>
           </div>
 
           <form onSubmit={handleSubmit} className="flex flex-col gap-3">
-            <div className="gum-card p-6 flex flex-col gap-3">
-              <input type="email" value={email} onChange={(e) => setEmail(e.target.value)} placeholder="이메일" autoComplete="email" className="gum-input" />
-              <input type="password" value={password} onChange={(e) => setPassword(e.target.value)} placeholder="비밀번호" autoComplete={mode === "signup" ? "new-password" : "current-password"} className="gum-input" />
-              <button type="submit" disabled={loading || !email.trim() || !password.trim()} className="gum-btn-pink w-full py-3.5 text-[15px] mt-1 disabled:opacity-40">
-                {loading ? <div className="w-5 h-5 border-2 border-black border-t-transparent rounded-full mx-auto" style={{ animation: "spin 0.8s linear infinite" }} /> : mode === "login" ? "로그인" : "회원가입"}
+            <div className="bg-bg-elevated border border-border rounded-xl p-5 flex flex-col gap-3">
+              <div>
+                <label className="text-[12px] text-text-tertiary mb-1 block">이메일</label>
+                <input type="email" value={email} onChange={(e) => setEmail(e.target.value)} placeholder="email@example.com" autoComplete="email" className="w-full bg-bg-secondary border border-border rounded-lg px-3 py-2.5 text-[14px] outline-none focus:border-accent focus:ring-1 focus:ring-accent/20 transition-all placeholder:text-text-tertiary" />
+              </div>
+              <div>
+                <label className="text-[12px] text-text-tertiary mb-1 block">비밀번호</label>
+                <input type="password" value={password} onChange={(e) => setPassword(e.target.value)} placeholder="••••••••" autoComplete={mode === "signup" ? "new-password" : "current-password"} className="w-full bg-bg-secondary border border-border rounded-lg px-3 py-2.5 text-[14px] outline-none focus:border-accent focus:ring-1 focus:ring-accent/20 transition-all placeholder:text-text-tertiary" />
+              </div>
+              <button type="submit" disabled={loading || !email.trim() || !password.trim()} className="w-full py-2.5 bg-accent text-white text-[14px] font-medium rounded-lg hover:bg-accent-hover transition-colors disabled:opacity-40 mt-1">
+                {loading ? <div className="w-4 h-4 border-2 border-white border-t-transparent rounded-full mx-auto" style={{ animation: "spin 0.8s linear infinite" }} /> : mode === "login" ? "로그인" : "회원가입"}
               </button>
             </div>
 
-            <div className="flex items-center gap-2 my-1">
-              <div className="flex-1 h-[2px] bg-border-subtle" />
-              <span className="text-text-tertiary text-xs font-bold">또는</span>
-              <div className="flex-1 h-[2px] bg-border-subtle" />
-            </div>
-
-            <button type="button" onClick={() => { setMode(mode === "login" ? "signup" : "login"); setError(null); setMessage(null); }} className="gum-btn w-full py-3 text-sm">
+            <button type="button" onClick={() => { setMode(mode === "login" ? "signup" : "login"); setError(null); setMessage(null); }} className="text-[13px] text-text-secondary hover:text-accent transition-colors text-center py-2">
               {mode === "login" ? "계정이 없으신가요? 회원가입" : "이미 계정이 있으신가요? 로그인"}
             </button>
 
-            {error && <div className="gum-card p-3 text-error text-sm font-medium text-center" style={{ borderColor: "var(--color-error)" }}>{error}</div>}
-            {message && <div className="gum-card p-3 text-success text-sm font-medium text-center" style={{ borderColor: "var(--color-success)" }}>{message}</div>}
+            {error && <div className="bg-error-light border border-error/20 rounded-lg p-3 text-error text-[13px] text-center">{error}</div>}
+            {message && <div className="bg-success-light border border-success/20 rounded-lg p-3 text-success text-[13px] text-center">{message}</div>}
           </form>
         </motion.div>
       </div>

--- a/src/components/calendar/CalendarGrid.tsx
+++ b/src/components/calendar/CalendarGrid.tsx
@@ -10,7 +10,6 @@ import { CompletionRing } from "./CompletionRing";
 import { MultiDayBar, OverflowIndicator } from "./MultiDayBar";
 import { splitByWeek, assignSlots, getOverflowCounts } from "@/lib/multiday";
 import { ThemeToggle } from "@/components/ThemeToggle";
-import { Doto } from "@/components/Doto";
 
 const WEEKDAYS = [0, 1, 2, 3, 4, 5, 6];
 
@@ -24,6 +23,7 @@ export function CalendarGrid() {
   const categories = useCalendarStore((s) => s.categories);
   const prevMonth = useCalendarStore((s) => s.prevMonth);
   const nextMonth = useCalendarStore((s) => s.nextMonth);
+  const getTodosForDate = useCalendarStore((s) => s.getTodosForDate);
 
   const days = useMemo(() => getMonthDays(currentYear, currentMonth), [currentYear, currentMonth]);
   const monthLabel = `${currentYear}년 ${currentMonth + 1}월`;
@@ -40,8 +40,6 @@ export function CalendarGrid() {
 
   useEffect(() => { setSwipeDirection(0); }, [currentYear, currentMonth]);
 
-  const getTodosForDate = useCalendarStore((s) => s.getTodosForDate);
-
   const cellData = useMemo(() => {
     const completionSet = new Set(completions.map((c) => `${c.todoId}:${c.completedDate}`));
     const catColorMap = new Map(categories.map((c) => [c.id, c.color]));
@@ -51,29 +49,15 @@ export function CalendarGrid() {
       const completedCount = dateTodos.filter((t) => completionSet.has(`${t.id}:${dateStr}`)).length;
       const rate = dateTodos.length === 0 ? -1 : completedCount / dateTodos.length;
       const dotColors = [...new Set(dateTodos.map((t) => t.categoryId ? catColorMap.get(t.categoryId) : undefined).filter(Boolean))].slice(0, 3) as string[];
-      const previews = dateTodos.slice(0, 3).map((t) => ({
+      const previews = dateTodos.slice(0, 2).map((t) => ({
         title: t.title,
         done: completionSet.has(`${t.id}:${dateStr}`),
         color: t.categoryId ? catColorMap.get(t.categoryId) : undefined,
       }));
-      const moreCount = Math.max(0, dateTodos.length - 3);
+      const moreCount = Math.max(0, dateTodos.length - 2);
       return { dateStr, date, rate, dotColors, previews, totalCount: dateTodos.length, completedCount, moreCount };
     });
   }, [days, todos, completions, categories, getTodosForDate]);
-
-  // Monthly stats
-  const monthStats = useMemo(() => {
-    let totalTodos = 0;
-    let totalCompleted = 0;
-    cellData.forEach((cell) => {
-      if (cell.date.getMonth() === currentMonth) {
-        totalTodos += cell.totalCount;
-        totalCompleted += cell.completedCount;
-      }
-    });
-    const rate = totalTodos === 0 ? 0 : Math.round((totalCompleted / totalTodos) * 100);
-    return { totalTodos, totalCompleted, rate };
-  }, [cellData, currentMonth]);
 
   const multiDaySegments = useMemo(() => {
     const multiDayTodos = todos.filter((t) => t.endDate && !t.isRoutine);
@@ -101,28 +85,33 @@ export function CalendarGrid() {
   const handleLogout = async () => { const supabase = createClient(); await supabase.auth.signOut(); window.location.reload(); };
 
   return (
-    <div className="h-full flex flex-col">
-      {/* Header — Pink energy bar */}
-      <div className="gum-header flex items-center justify-between px-4 lg:px-6 py-3">
+    <div className="h-full flex flex-col bg-bg-elevated rounded-lg lg:rounded-xl overflow-hidden border border-border">
+      {/* Header */}
+      <div className="flex items-center justify-between px-4 lg:px-5 py-3 border-b border-border">
         <div className="flex items-center gap-3">
-          <Doto mood="wave" size={32} className="hidden lg:block" />
-          <h1 className="text-[24px] lg:text-[28px] font-black tracking-tight">{monthLabel}</h1>
+          <button onClick={prevMonth} className="w-8 h-8 flex items-center justify-center rounded-lg text-text-secondary hover:bg-bg-secondary hover:text-text-primary transition-colors">
+            <svg width="16" height="16" viewBox="0 0 16 16" fill="none"><path d="M10 12L6 8L10 4" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/></svg>
+          </button>
+          <h1 className="text-[17px] lg:text-[19px] font-semibold tracking-tight">{monthLabel}</h1>
+          <button onClick={nextMonth} className="w-8 h-8 flex items-center justify-center rounded-lg text-text-secondary hover:bg-bg-secondary hover:text-text-primary transition-colors">
+            <svg width="16" height="16" viewBox="0 0 16 16" fill="none"><path d="M6 12L10 8L6 4" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/></svg>
+          </button>
         </div>
-        <div className="flex gap-2 items-center">
-          <button onClick={prevMonth} className="gum-btn w-9 h-9 text-lg ">‹</button>
-          <button onClick={nextMonth} className="gum-btn w-9 h-9 text-lg ">›</button>
+        <div className="flex gap-1.5 items-center">
           <ThemeToggle />
-          <button onClick={handleLogout} className="gum-btn w-9 h-9 text-xs " aria-label="로그아웃">⏻</button>
+          <button onClick={handleLogout} className="w-8 h-8 flex items-center justify-center rounded-lg text-text-secondary hover:bg-bg-secondary transition-colors" aria-label="로그아웃">
+            <svg width="16" height="16" viewBox="0 0 16 16" fill="none"><path d="M6 14H3.333A1.333 1.333 0 012 12.667V3.333A1.333 1.333 0 013.333 2H6M10.667 11.333L14 8l-3.333-3.333M14 8H6" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/></svg>
+          </button>
         </div>
       </div>
 
-      {/* Weekday labels — colored row */}
-      <div className="grid grid-cols-7 gum-weekday-row border-b-2 border-border-subtle">
+      {/* Weekday labels */}
+      <div className="grid grid-cols-7 border-b border-border">
         {WEEKDAYS.map((dow) => (
           <div
             key={dow}
-            className={`text-center text-[12px] font-black py-2.5 uppercase border-r-2 border-border-subtle last:border-r-0 ${
-              dow === 0 ? "gum-weekday-sun" : dow === 6 ? "gum-weekday-sat" : ""
+            className={`text-center text-[11px] font-medium py-2 ${
+              dow === 0 ? "text-sun" : dow === 6 ? "text-sat" : "text-text-tertiary"
             }`}
           >
             {getWeekdayLabel(dow)}
@@ -130,17 +119,17 @@ export function CalendarGrid() {
         ))}
       </div>
 
-      {/* Grid — fills remaining space */}
-      <div ref={gridRef} className="flex-1 flex flex-col min-h-0 overflow-hidden">
+      {/* Grid */}
+      <div ref={gridRef} className="flex-1 flex flex-col min-h-0">
         <motion.div
           className="flex-1 flex flex-col min-h-0"
           drag="x"
           dragConstraints={{ left: 0, right: 0 }}
-          dragElastic={0.2}
+          dragElastic={0.15}
           onDragEnd={handleDragEnd}
           animate={controls}
           key={`${currentYear}-${currentMonth}`}
-          initial={{ x: swipeDirection * 100, opacity: 0.5 }}
+          initial={{ x: swipeDirection * 80, opacity: 0.6 }}
           transition={{ type: "spring", ...springs.navigate }}
         >
           {Array.from({ length: numWeeks }, (_, weekIdx) => {
@@ -150,108 +139,84 @@ export function CalendarGrid() {
             return (
               <div key={weekIdx} className="relative flex-1 min-h-0 overflow-hidden">
                 <div className="grid grid-cols-7 h-full">
-                {weekDays.map((cell, colIdx) => {
-                  const isCurrentMonth = cell.date.getMonth() === currentMonth;
-                  const today = isToday(cell.date);
-                  const isSelected = cell.dateStr === selectedDate;
-                  const allDone = cell.rate === 1;
-                  const hasTodos = cell.totalCount > 0;
+                  {weekDays.map((cell, colIdx) => {
+                    const isCurrentMonth = cell.date.getMonth() === currentMonth;
+                    const today = isToday(cell.date);
+                    const isSelected = cell.dateStr === selectedDate;
 
-                  return (
-                    <motion.button
-                      key={`${cell.dateStr}-${weekIdx * 7 + colIdx}`}
-                      layoutId={`day-${cell.dateStr}`}
-                      onClick={() => selectDate(cell.dateStr)}
-                      className={`
-                        relative flex flex-col items-start pt-1.5 px-1 min-h-[56px] lg:min-h-0 h-full
-                        border-r-2 border-b-2 border-border-subtle last:border-r-0 transition-colors text-left
-                        ${isCurrentMonth ? "" : "opacity-20"}
-                        ${isSelected ? "bg-accent/20 ring-2 ring-inset ring-accent" : ""}
-                        ${!isSelected && allDone && hasTodos ? "gum-cell-all-done" : ""}
-                        ${!isSelected && !allDone && hasTodos ? "gum-cell-has-todos" : ""}
-                        ${!isSelected && !today ? "hover:bg-bg-elevated" : ""}
-                      `}
-                      whileTap={{ scale: 0.97 }}
-                    >
-                      {/* Date number row */}
-                      <div className="flex items-center gap-1 w-full">
-                        <div className="relative flex items-center justify-center">
+                    return (
+                      <button
+                        key={`${cell.dateStr}-${weekIdx * 7 + colIdx}`}
+                        onClick={() => selectDate(cell.dateStr)}
+                        className={`
+                          relative flex flex-col items-start pt-1.5 lg:pt-2 px-1 lg:px-1.5 min-h-[52px] h-full
+                          border-r border-b border-border-light transition-colors text-left
+                          ${isCurrentMonth ? "" : "opacity-30"}
+                          ${isSelected ? "bg-accent-light" : "hover:bg-bg-secondary"}
+                        `}
+                      >
+                        {/* Date */}
+                        <div className="flex items-center gap-0.5 w-full mb-0.5">
                           {today ? (
-                            <span className="w-7 h-7 rounded-full bg-accent text-black flex items-center justify-center text-[13px] font-black" style={{ animation: "today-pulse 2s ease-in-out 3" }}>
+                            <span className="w-6 h-6 rounded-full bg-accent text-white flex items-center justify-center text-[12px] font-semibold" style={{ animation: "today-pulse 2s ease-in-out 3" }}>
                               {cell.date.getDate()}
                             </span>
                           ) : (
-                            <span className={`text-[13px] font-bold w-7 h-7 flex items-center justify-center ${isSelected ? "text-accent" : colIdx === 0 ? "text-cat-red" : colIdx === 6 ? "text-cat-blue" : ""}`}>
+                            <span className={`text-[12px] font-medium w-6 h-6 flex items-center justify-center rounded-full ${
+                              isSelected ? "bg-accent text-white" : colIdx === 0 ? "text-sun" : colIdx === 6 ? "text-sat" : "text-text-primary"
+                            }`}>
                               {cell.date.getDate()}
                             </span>
                           )}
-                          {cell.rate >= 0 && <CompletionRing rate={cell.rate} color={cell.dotColors[0] || "#FF90E8"} size={26} />}
+                          {cell.rate > 0 && <CompletionRing rate={cell.rate} color={cell.dotColors[0] || "var(--color-accent)"} size={22} />}
                         </div>
-                        {/* Category dots — compact */}
+
+                        {/* Todo previews — desktop */}
+                        <div className="hidden lg:flex flex-col gap-px w-full overflow-hidden flex-1">
+                          {cell.previews.map((p, i) => (
+                            <div
+                              key={i}
+                              className={`text-[10px] leading-[14px] font-medium truncate rounded px-1 py-px ${
+                                p.done ? "line-through text-text-tertiary" : "text-text-primary"
+                              }`}
+                              style={p.color ? { backgroundColor: `${p.color}15`, borderLeft: `2px solid ${p.color}` } : { backgroundColor: "var(--color-bg-secondary)" }}
+                            >
+                              {p.title}
+                            </div>
+                          ))}
+                          {cell.moreCount > 0 && (
+                            <span className="text-[9px] font-medium text-text-tertiary px-1">+{cell.moreCount}개</span>
+                          )}
+                        </div>
+
+                        {/* Dots — mobile */}
                         {cell.dotColors.length > 0 && (
-                          <div className="flex gap-[2px]">
+                          <div className="flex gap-[3px] lg:hidden mt-0.5">
                             {cell.dotColors.map((color) => (
                               <span key={color} className="w-[5px] h-[5px] rounded-full" style={{ backgroundColor: color }} />
                             ))}
                           </div>
                         )}
-                      </div>
+                      </button>
+                    );
+                  })}
+                </div>
 
-                      {/* Todo previews — desktop only */}
-                      <div className="hidden lg:flex flex-col gap-[1px] mt-0.5 w-full overflow-hidden flex-1">
-                        {cell.previews.map((p, i) => (
-                          <div
-                            key={i}
-                            className={`gum-cell-preview ${p.done ? "gum-cell-preview-done" : ""}`}
-                            style={p.color ? { borderLeft: `2px solid ${p.color}`, paddingLeft: 3 } : undefined}
-                          >
-                            {p.title}
-                          </div>
-                        ))}
-                        {cell.moreCount > 0 && (
-                          <span className="text-[8px] font-black text-accent">+{cell.moreCount}</span>
-                        )}
-                      </div>
-                    </motion.button>
-                  );
-                })}
-              </div>
-
-              {cellWidth > 0 && weekSegments.filter((s) => s.slot !== -1).map((seg) => (
-                <MultiDayBar key={`bar-${seg.todo.id}-${seg.row}`} segment={seg} cellWidth={cellWidth} onTap={selectDate} />
-              ))}
-              {cellWidth > 0 && Array.from(overflowCounts.entries())
-                .filter(([key]) => key.startsWith(`${weekIdx}-`))
-                .map(([key, count]) => {
-                  const col = parseInt(key.split("-")[1]);
-                  const cellDate = weekDays[col]?.dateStr;
-                  if (!cellDate) return null;
-                  return <OverflowIndicator key={key} count={count} row={weekIdx} col={col} cellWidth={cellWidth} onTap={selectDate} date={cellDate} />;
-                })}
+                {cellWidth > 0 && weekSegments.filter((s) => s.slot !== -1).map((seg) => (
+                  <MultiDayBar key={`bar-${seg.todo.id}-${seg.row}`} segment={seg} cellWidth={cellWidth} onTap={selectDate} />
+                ))}
+                {cellWidth > 0 && Array.from(overflowCounts.entries())
+                  .filter(([key]) => key.startsWith(`${weekIdx}-`))
+                  .map(([key, count]) => {
+                    const col = parseInt(key.split("-")[1]);
+                    const cellDate = weekDays[col]?.dateStr;
+                    if (!cellDate) return null;
+                    return <OverflowIndicator key={key} count={count} row={weekIdx} col={col} cellWidth={cellWidth} onTap={selectDate} date={cellDate} />;
+                  })}
               </div>
             );
           })}
         </motion.div>
-      </div>
-
-      {/* Monthly Stats Bar */}
-      <div className="gum-stats-bar">
-        <span className="text-text-secondary text-[11px]">이번 달</span>
-        <span className="gum-stat-pill">
-          <span style={{ color: "var(--color-accent)" }}>●</span>
-          할 일 {monthStats.totalTodos}
-        </span>
-        <span className="gum-stat-pill">
-          <span style={{ color: "var(--color-success)" }}>✓</span>
-          완료 {monthStats.totalCompleted}
-        </span>
-        {monthStats.totalTodos > 0 && (
-          <span className={`gum-stat-pill ${monthStats.rate === 100 ? "!bg-accent/20 !border-accent" : ""}`}>
-            {monthStats.rate}%
-          </span>
-        )}
-        <div className="flex-1" />
-        <Doto mood={monthStats.rate === 100 ? "celebrate" : monthStats.rate >= 50 ? "wave" : "think"} size={28} />
       </div>
     </div>
   );

--- a/src/components/calendar/MultiDayBar.tsx
+++ b/src/components/calendar/MultiDayBar.tsx
@@ -10,30 +10,31 @@ interface MultiDayBarProps {
   onTap: (date: string) => void;
 }
 
-const BAR_HEIGHT = 16;
+const BAR_HEIGHT = 18;
 const BAR_GAP = 2;
-const BAR_TOP_OFFSET = 32; // below date number + completion ring
+const BAR_TOP_OFFSET = 30;
 
 export function MultiDayBar({ segment, cellWidth, onTap }: MultiDayBarProps) {
   if (segment.slot === -1) return null;
 
-  const color = segment.color || "#5CC8FF";
-  const left = segment.startCol * cellWidth;
-  const width = segment.span * cellWidth - 2; // 2px gap
+  const color = segment.color || "var(--color-accent)";
+  const left = segment.startCol * cellWidth + 1;
+  const width = segment.span * cellWidth - 2;
   const top = BAR_TOP_OFFSET + segment.slot * (BAR_HEIGHT + BAR_GAP);
 
   return (
     <motion.button
-      className="absolute text-[10px] font-medium px-1.5 rounded-[3px] truncate leading-[16px]"
+      className="absolute text-[10px] font-medium px-1.5 rounded-[4px] truncate leading-[18px]"
       style={{
         left,
         top,
-        width,
+        width: Math.max(0, width),
         height: BAR_HEIGHT,
-        backgroundColor: `${color}30`,
+        backgroundColor: `${color}20`,
         color,
+        borderLeft: `2px solid ${color}`,
       }}
-      initial={{ opacity: 0, scaleX: 0.8 }}
+      initial={{ opacity: 0, scaleX: 0.9 }}
       animate={{ opacity: 1, scaleX: 1 }}
       transition={{ type: "spring", ...springs.elastic }}
       onClick={() => onTap(segment.todo.startDate)}
@@ -45,7 +46,6 @@ export function MultiDayBar({ segment, cellWidth, onTap }: MultiDayBarProps) {
 
 export function OverflowIndicator({
   count,
-  row,
   col,
   cellWidth,
   onTap,
@@ -63,11 +63,11 @@ export function OverflowIndicator({
 
   return (
     <button
-      className="absolute text-[9px] font-semibold text-text-secondary"
-      style={{ left: left + 2, top }}
+      className="absolute text-[9px] font-medium text-text-tertiary hover:text-accent transition-colors"
+      style={{ left: left + 4, top }}
       onClick={() => onTap(date)}
     >
-      +{count}
+      +{count}개
     </button>
   );
 }

--- a/src/components/todo/TodoAdd.tsx
+++ b/src/components/todo/TodoAdd.tsx
@@ -31,49 +31,59 @@ export function TodoAdd({ date }: TodoAddProps) {
   };
 
   return (
-    <div className="mt-3">
+    <div>
       <AnimatePresence mode="wait">
         {isAdding ? (
           <motion.div key="form" initial={{ opacity: 0, height: 0 }} animate={{ opacity: 1, height: "auto" }} exit={{ opacity: 0, height: 0 }} transition={{ type: "spring", ...springs.reorder }} className="overflow-hidden">
-            <div className="gum-card p-4 mt-2">
-              <input type="text" value={title} onChange={(e) => setTitle(e.target.value)} onKeyDown={(e) => { if (e.key === "Enter") handleSubmit(); if (e.key === "Escape") resetForm(); }} placeholder="할 일을 입력하세요" autoFocus className="gum-input mb-3" />
+            <div className="bg-bg-elevated border border-border rounded-xl p-4">
+              <input
+                type="text" value={title} onChange={(e) => setTitle(e.target.value)}
+                onKeyDown={(e) => { if (e.key === "Enter") handleSubmit(); if (e.key === "Escape") resetForm(); }}
+                placeholder="할 일을 입력하세요"
+                autoFocus
+                className="w-full bg-bg-secondary border border-border rounded-lg px-3 py-2.5 text-[14px] outline-none focus:border-accent focus:ring-1 focus:ring-accent/20 transition-all placeholder:text-text-tertiary"
+              />
 
-              <div className="flex gap-2 mb-3 overflow-x-auto">
+              <div className="flex gap-1.5 mt-3 overflow-x-auto">
                 {categories.map((cat) => (
                   <button key={cat.id} onClick={() => setSelectedCategoryId(cat.id)}
-                    className="text-[10px] font-black px-3 py-1 rounded-full whitespace-nowrap border-2 transition-all"
-                    style={{ backgroundColor: selectedCategoryId === cat.id ? `${cat.color}25` : "transparent", color: cat.color, borderColor: selectedCategoryId === cat.id ? cat.color : "transparent" }}>
+                    className="text-[11px] font-medium px-2.5 py-1 rounded-full whitespace-nowrap transition-all"
+                    style={{
+                      backgroundColor: selectedCategoryId === cat.id ? `${cat.color}20` : "transparent",
+                      color: selectedCategoryId === cat.id ? cat.color : "var(--color-text-secondary)",
+                      border: `1px solid ${selectedCategoryId === cat.id ? cat.color : "var(--color-border)"}`,
+                    }}>
                     {cat.name}
                   </button>
                 ))}
               </div>
 
-              <div className="flex gap-2 mb-3">
+              <div className="flex gap-1.5 mt-3">
                 {[
                   { label: "단일", active: !isRoutine && !endDate, onClick: () => { setIsRoutine(false); setEndDate(""); } },
                   { label: "기간", active: !isRoutine && !!endDate, onClick: () => { setIsRoutine(false); setEndDate(date); } },
                   { label: "루틴", active: isRoutine, onClick: () => { setIsRoutine(true); setEndDate(""); } },
                 ].map(({ label, active, onClick }) => (
-                  <button key={label} onClick={onClick} className={`text-[11px] font-bold px-3 py-1 rounded-full border-2 transition-all ${active ? "bg-accent/20 text-accent border-accent" : "text-text-secondary border-border-subtle"}`}>
+                  <button key={label} onClick={onClick} className={`text-[11px] font-medium px-3 py-1 rounded-full border transition-all ${active ? "bg-accent text-white border-accent" : "text-text-secondary border-border"}`}>
                     {label}
                   </button>
                 ))}
               </div>
 
               {!isRoutine && endDate && (
-                <div className="mb-3">
-                  <label className="text-[11px] text-text-secondary font-bold block mb-1">종료일</label>
-                  <input type="date" value={endDate} min={date} onChange={(e) => setEndDate(e.target.value)} className="gum-input text-sm" />
+                <div className="mt-3">
+                  <label className="text-[11px] text-text-tertiary block mb-1">종료일</label>
+                  <input type="date" value={endDate} min={date} onChange={(e) => setEndDate(e.target.value)} className="w-full bg-bg-secondary border border-border rounded-lg px-3 py-2 text-[13px] outline-none focus:border-accent transition-all" />
                 </div>
               )}
 
               {isRoutine && (
-                <div className="mb-3">
-                  <label className="text-[11px] text-text-secondary font-bold block mb-1.5">반복 요일</label>
-                  <div className="flex gap-1.5">
+                <div className="mt-3">
+                  <label className="text-[11px] text-text-tertiary block mb-1.5">반복 요일</label>
+                  <div className="flex gap-1">
                     {WEEKDAYS.map((dow) => (
                       <button key={dow} onClick={() => setRoutineDays((prev) => prev.includes(dow) ? prev.filter((d) => d !== dow) : [...prev, dow])}
-                        className={`w-8 h-8 rounded-full text-[11px] font-bold border-2 transition-all ${routineDays.includes(dow) ? "bg-accent text-black border-accent" : "text-text-secondary border-border-subtle"}`}>
+                        className={`w-8 h-8 rounded-full text-[11px] font-medium transition-all ${routineDays.includes(dow) ? "bg-accent text-white" : "text-text-secondary border border-border"}`}>
                         {getWeekdayLabel(dow)}
                       </button>
                     ))}
@@ -81,16 +91,16 @@ export function TodoAdd({ date }: TodoAddProps) {
                 </div>
               )}
 
-              <div className="flex gap-2">
-                <button onClick={handleSubmit} disabled={!title.trim() || (isRoutine && routineDays.length === 0)} className="gum-btn-pink flex-1 py-2.5 text-sm disabled:opacity-40">추가</button>
-                <button onClick={resetForm} className="gum-btn px-4 py-2.5 text-sm">취소</button>
+              <div className="flex gap-2 mt-4">
+                <button onClick={handleSubmit} disabled={!title.trim() || (isRoutine && routineDays.length === 0)} className="flex-1 py-2 bg-accent text-white text-[13px] font-medium rounded-lg hover:bg-accent-hover transition-colors disabled:opacity-40">추가</button>
+                <button onClick={resetForm} className="px-4 py-2 text-[13px] text-text-secondary rounded-lg border border-border hover:bg-bg-secondary transition-colors">취소</button>
               </div>
-              {error && <p className="text-error text-xs mt-2 font-bold">{error}</p>}
+              {error && <p className="text-error text-[12px] mt-2">{error}</p>}
             </div>
           </motion.div>
         ) : (
-          <motion.button key="button" onClick={() => setIsAdding(true)} className="flex items-center gap-2 py-3 text-text-tertiary text-[14px] font-bold hover:text-accent transition-colors w-full" initial={{ opacity: 0 }} animate={{ opacity: 1 }}>
-            <span className="w-6 h-6 rounded-[var(--radius-sm)] border-[2.5px] border-dashed border-text-tertiary flex items-center justify-center text-sm font-black">+</span>
+          <motion.button key="button" onClick={() => setIsAdding(true)} className="flex items-center gap-2 px-2 py-2 text-text-tertiary text-[13px] hover:text-accent transition-colors w-full rounded-lg hover:bg-accent-light" initial={{ opacity: 0 }} animate={{ opacity: 1 }}>
+            <svg width="16" height="16" viewBox="0 0 16 16" fill="none"><path d="M8 3v10M3 8h10" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round"/></svg>
             <span>할 일 추가</span>
           </motion.button>
         )}

--- a/src/components/todo/TodoItem.tsx
+++ b/src/components/todo/TodoItem.tsx
@@ -17,14 +17,14 @@ export function TodoItem({ todo, date, category, completed = false }: TodoItemPr
   const checkboxRef = useRef<HTMLButtonElement>(null);
   const [scope, animate] = useAnimate();
 
-  const color = category?.color || "#FF90E8";
+  const color = category?.color || "var(--color-accent)";
 
   const handleToggle = async () => {
     const wasCompleted = isCompleted(todo.id, date);
     await toggleCompletion(todo.id, date);
     if (!wasCompleted && checkboxRef.current) {
       playCompletionSound();
-      await animate(checkboxRef.current, { scale: [1, 1.3, 1] }, { duration: 0.25, type: "spring", ...springs.check });
+      await animate(checkboxRef.current, { scale: [1, 1.2, 1] }, { duration: 0.2, type: "spring", ...springs.check });
       const rect = checkboxRef.current.getBoundingClientRect();
       spawnParticles(rect.left + rect.width / 2, rect.top + rect.height / 2, color);
       const allTodos = getTodosForDate(date);
@@ -34,23 +34,33 @@ export function TodoItem({ todo, date, category, completed = false }: TodoItemPr
   };
 
   return (
-    <div ref={scope} className={`flex items-center gap-3 py-3 ${completed ? "opacity-35" : ""}`}>
+    <div ref={scope} className={`flex items-center gap-3 px-2 py-2.5 rounded-lg transition-colors ${completed ? "opacity-50" : "hover:bg-bg-secondary"}`}>
       <motion.button
         ref={checkboxRef}
         onClick={handleToggle}
-        className="w-6 h-6 rounded-[var(--radius-sm)] border-[2.5px] flex items-center justify-center flex-shrink-0"
-        style={{ borderColor: color, backgroundColor: completed ? color : "transparent" }}
+        className="w-[18px] h-[18px] rounded-[5px] border-[1.5px] flex items-center justify-center flex-shrink-0 transition-colors"
+        style={{
+          borderColor: completed ? color : "var(--color-border)",
+          backgroundColor: completed ? color : "transparent",
+        }}
         whileTap={{ scale: 0.85 }}
       >
-        {completed && <span className="text-black text-[14px] font-black">✓</span>}
+        {completed && (
+          <svg width="10" height="10" viewBox="0 0 10 10" fill="none">
+            <path d="M2 5L4 7L8 3" stroke="white" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/>
+          </svg>
+        )}
       </motion.button>
 
-      <span className={`flex-1 text-[15px] font-medium ${completed ? "text-text-tertiary line-through" : "text-text-primary"}`}>
+      <span className={`flex-1 text-[14px] ${completed ? "text-text-tertiary line-through" : "text-text-primary"}`}>
         {todo.title}
       </span>
 
       {category && (
-        <span className="text-[10px] font-black px-2.5 py-1 rounded-full border-2" style={{ borderColor: color, color, backgroundColor: `${color}15` }}>
+        <span
+          className="text-[10px] font-medium px-2 py-0.5 rounded-full"
+          style={{ backgroundColor: `${category.color}15`, color: category.color }}
+        >
           {category.name}
         </span>
       )}

--- a/src/components/todo/TodoList.tsx
+++ b/src/components/todo/TodoList.tsx
@@ -7,7 +7,6 @@ import { TodoItem } from "./TodoItem";
 import { TodoAdd } from "./TodoAdd";
 import { parseDate, getWeekdayLabel } from "@/lib/date";
 import { springs } from "@/lib/springs";
-import { Doto } from "@/components/Doto";
 
 interface TodoListProps { desktopMode?: boolean; }
 
@@ -47,80 +46,74 @@ export function TodoList({ desktopMode = false }: TodoListProps) {
   const weekday = getWeekdayLabel(date.getDay()) + "요일";
   const incompleteTodos = dateTodos.filter((t) => !completionSet.has(t.id));
   const completedTodos = dateTodos.filter((t) => completionSet.has(t.id));
-  const allDone = dateTodos.length > 0 && completedTodos.length === dateTodos.length;
 
   return (
     <motion.div
-      className={desktopMode ? "h-full flex flex-col" : "min-h-screen flex flex-col"}
+      className={desktopMode ? "h-full flex flex-col" : "min-h-screen flex flex-col bg-bg-secondary"}
       initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }} transition={{ duration: 0.15 }}
     >
-      {/* Pink header */}
-      <div className="gum-panel-header">
-        <div className="flex items-center gap-3">
-          {!desktopMode && (
-            <button onClick={() => selectDate(null)} className="gum-btn w-8 h-8 text-sm font-bold ">←</button>
+      {/* Header */}
+      <div className="px-5 pt-5 pb-3 border-b border-border flex items-center gap-3">
+        <button
+          onClick={() => selectDate(null)}
+          className="w-8 h-8 flex items-center justify-center rounded-lg text-text-secondary hover:bg-bg-secondary transition-colors"
+        >
+          {desktopMode ? (
+            <svg width="16" height="16" viewBox="0 0 16 16" fill="none"><path d="M12 4L4 12M4 4l8 8" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round"/></svg>
+          ) : (
+            <svg width="16" height="16" viewBox="0 0 16 16" fill="none"><path d="M10 12L6 8l4-4" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/></svg>
           )}
-          {desktopMode && (
-            <button onClick={() => selectDate(null)} className="gum-btn w-7 h-7 text-xs font-bold ">✕</button>
-          )}
-          <motion.div layoutId={desktopMode ? undefined : `day-${selectedDate}`}>
-            <h1 className="text-[22px] font-black tracking-tight">
-              {dayLabel}
-              <span className="text-[13px] font-bold opacity-70 ml-2">{weekday}</span>
-            </h1>
-          </motion.div>
+        </button>
+        <div className="flex-1">
+          <h1 className="text-[17px] font-semibold tracking-tight">{dayLabel}</h1>
+          <p className="text-[12px] text-text-tertiary">{weekday}</p>
         </div>
-
-        {/* Mini stats in header */}
         {dateTodos.length > 0 && (
-          <div className="flex items-center gap-2 mt-2">
-            <span className="text-[11px] font-bold opacity-80">
-              {completedTodos.length}/{dateTodos.length} 완료
+          <div className="flex items-center gap-2">
+            <span className="text-[12px] font-medium text-text-secondary">
+              {completedTodos.length}/{dateTodos.length}
             </span>
-            <div className="flex-1 h-1.5 bg-black/15 rounded-full overflow-hidden">
+            <div className="w-16 h-1.5 bg-border rounded-full overflow-hidden">
               <motion.div
-                className="h-full rounded-full"
-                style={{ backgroundColor: allDone ? "var(--color-success)" : "#000" }}
+                className="h-full rounded-full bg-accent"
                 initial={{ width: 0 }}
-                animate={{ width: `${dateTodos.length === 0 ? 0 : (completedTodos.length / dateTodos.length) * 100}%` }}
+                animate={{ width: `${(completedTodos.length / dateTodos.length) * 100}%` }}
                 transition={{ type: "spring", stiffness: 200, damping: 25 }}
               />
             </div>
-            {allDone && <Doto mood="celebrate" size={24} />}
           </div>
         )}
       </div>
 
       {/* Content */}
-      <div className="flex-1 overflow-y-auto px-4 pt-4 pb-8">
-        <div className="gum-card p-4">
-          {dateTodos.length === 0 ? (
-            <div className="flex flex-col items-center justify-center py-12">
-              <Doto mood="sleep" size={72} />
-              <p className="text-text-tertiary text-[14px] mt-3 font-bold">아직 할 일이 없어요</p>
+      <div className="flex-1 overflow-y-auto px-5 py-4">
+        {dateTodos.length === 0 ? (
+          <div className="flex flex-col items-center justify-center py-16 text-center">
+            <div className="w-12 h-12 rounded-full bg-bg-secondary flex items-center justify-center mb-3">
+              <svg width="24" height="24" viewBox="0 0 24 24" fill="none"><path d="M12 5v14M5 12h14" stroke="var(--color-text-tertiary)" strokeWidth="1.5" strokeLinecap="round"/></svg>
             </div>
-          ) : (
-            <div>
-              {incompleteTodos.map((todo, i) => (
-                <motion.div key={todo.id} initial={{ opacity: 0, x: -8 }} animate={{ opacity: 1, x: 0 }} transition={{ delay: i * 0.03, type: "spring", ...springs.reorder }}>
-                  <TodoItem todo={todo} date={selectedDate} category={categoryMap.get(todo.categoryId ?? "")} />
-                </motion.div>
-              ))}
-              {completedTodos.length > 0 && (
-                <>
-                  <div className="flex items-center gap-2 my-3">
-                    <div className="flex-1 h-[2px] bg-border-subtle" />
-                    <span className="gum-card-pink px-3 py-0.5 text-[10px] font-black">완료 {completedTodos.length}</span>
-                    <div className="flex-1 h-[2px] bg-border-subtle" />
-                  </div>
-                  {completedTodos.map((todo) => (
-                    <TodoItem key={todo.id} todo={todo} date={selectedDate} category={categoryMap.get(todo.categoryId ?? "")} completed />
-                  ))}
-                </>
-              )}
-            </div>
-          )}
+            <p className="text-text-tertiary text-[14px]">할 일이 없습니다</p>
+            <p className="text-text-tertiary text-[12px] mt-1">아래에서 추가해보세요</p>
+          </div>
+        ) : (
+          <div className="space-y-1">
+            {incompleteTodos.map((todo, i) => (
+              <motion.div key={todo.id} initial={{ opacity: 0, y: 4 }} animate={{ opacity: 1, y: 0 }} transition={{ delay: i * 0.03, type: "spring", ...springs.reorder }}>
+                <TodoItem todo={todo} date={selectedDate} category={categoryMap.get(todo.categoryId ?? "")} />
+              </motion.div>
+            ))}
+            {completedTodos.length > 0 && (
+              <div className="pt-3 mt-3 border-t border-border-light">
+                <p className="text-[11px] font-medium text-text-tertiary mb-2 px-1">완료됨 ({completedTodos.length})</p>
+                {completedTodos.map((todo) => (
+                  <TodoItem key={todo.id} todo={todo} date={selectedDate} category={categoryMap.get(todo.categoryId ?? "")} completed />
+                ))}
+              </div>
+            )}
+          </div>
+        )}
 
+        <div className="mt-4">
           <TodoAdd date={selectedDate} />
         </div>
       </div>


### PR DESCRIPTION
## Summary
- 기존 Gumroad Bold 스타일 **전부 제거**
- Figma Content Calendar 기반 **클린 미니멀**로 전면 교체
- 검정 2px 보더 → **1px 그레이**, 핑크 → **Indigo(#6366F1)**
- bg-secondary 위 카드가 떠 있는 레이아웃
- SVG 아이콘 버튼, 소프트 체크박스, 여백 기반 구분
- Doto 캐릭터 미사용
- 10개 파일 변경, -654줄 / +420줄 (코드 정리)

## Test plan
- [x] `next build` 성공
- [x] vitest 43/43 통과